### PR TITLE
Add IEEE2026 directories with documentation

### DIFF
--- a/IEEE2026/SEC/README.md
+++ b/IEEE2026/SEC/README.md
@@ -1,0 +1,18 @@
+# SoutheasternCon Competition Code
+
+The `SEC` directory is reserved for production-ready code and assets that will be deployed during the 2026 SoutheasternCon competition run.
+
+## Scope
+- Stable firmware releases for the competition robot.
+- Configuration files, calibration values, and mission scripts vetted through full integration testing.
+- Documentation of deployment procedures and emergency rollback plans.
+
+## Workflow Expectations
+1. Develop features in subsystem folders (e.g., `../movement`) and validate them via `../testing` before promoting them here.
+2. Use semantic versioning or tagged releases to track competition builds.
+3. Record known issues, TODOs, and operator notes in this README or linked documents.
+
+## Deployment Checklist
+- Verify the robot passes hardware safety inspections and software self-tests.
+- Confirm all dependencies, toolchains, and flashing procedures are documented.
+- Archive released binaries and configuration snapshots alongside the source code.

--- a/IEEE2026/docs/README.md
+++ b/IEEE2026/docs/README.md
@@ -1,0 +1,16 @@
+# Documentation Hub
+
+Use this folder to collect subsystem design notes, field diagrams, meeting minutes, and external references relevant to the 2026 build season.
+
+## Suggested Structure
+- `architecture/` – block diagrams, interface definitions, and system-level design documents.
+- `hardware/` – wiring schematics, CAD exports, and vendor datasheets.
+- `software/` – API references, flowcharts, and onboarding guides.
+- `planning/` – sprint plans, retrospectives, and risk assessments.
+
+Feel free to create additional folders as the season progresses, but keep the README up to date so newcomers can navigate easily.
+
+## Best Practices
+- Prefer editable source formats (e.g., draw.io, Markdown) and include export instructions when using proprietary tools.
+- Link to large assets stored in shared drives rather than committing binaries that exceed repository limits.
+- Reference related testing artifacts in `../testing` to keep documentation and validation connected.

--- a/IEEE2026/movement/README.md
+++ b/IEEE2026/movement/README.md
@@ -1,0 +1,21 @@
+# Movement Subsystem
+
+This directory will host firmware and control logic for the robot's drive base and motion subsystems.
+
+## Contents
+- Motion control algorithms and libraries.
+- Interface layers for sensors such as IMUs, wheel encoders, and odometry modules.
+- Utilities for tuning PID controllers and motion profiles.
+
+## Getting Started
+1. Review the subsystem design notes in the main IEEE 2026 README and the team's Notion space.
+2. Create a feature branch for your work (e.g., `feature/drive-profile-generator`).
+3. Add source files and update this README with build and deployment steps as the subsystem grows.
+
+## Testing
+- Pair movement changes with relevant simulation or bench tests stored in `../testing`.
+- Document calibration procedures and expected performance metrics.
+
+## Contributing
+- Follow the software standards outlined by the team.
+- Keep diagrams, calculations, and notes alongside the code or link to shared documentation in `../docs`.

--- a/IEEE2026/testing/README.md
+++ b/IEEE2026/testing/README.md
@@ -1,0 +1,18 @@
+# Testing and Simulation
+
+This area holds tools, datasets, and notes for validating the robot in simulation and on hardware benches.
+
+## What Belongs Here
+- Simulation environments and configuration files (e.g., Gazebo, Webots, custom Python scripts).
+- Bench test harnesses for subsystems such as drive motors, manipulators, or sensors.
+- Recorded telemetry, log files, and analysis notebooks.
+
+## Usage Guidelines
+1. Organize new tooling into descriptive subdirectories (e.g., `simulation/`, `hardware/`, `data/`).
+2. Provide setup instructions, dependencies, and run commands for each test harness.
+3. Include expected results or acceptance criteria to help other members reproduce your findings.
+
+## Reporting Results
+- Summarize key findings in markdown files or link to documentation in `../docs`.
+- Note any hardware-specific requirements (power supplies, fixtures, safety considerations).
+- Keep test assets synchronized with the movement and SEC codebases to catch regressions early.


### PR DESCRIPTION
## Summary
- create the IEEE2026 subsystem folders for movement, testing, docs, and SEC
- document the purpose and usage expectations for each area with placeholder READMEs

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d13e5aa6308328816ce519790bdcec