### PR TITLE
Add Arduino blink example and document examples folder

### DIFF
--- a/IEEE2026/README.md
+++ b/IEEE2026/README.md
@@ -40,6 +40,7 @@ The 2026 repository will grow throughout the season. Organize new folders as fol
 | `testing/` | Scripts and assets for desktop testing, ROS nodes, or kinematic models. |
 | `SEC/` | Folder for Southeast Con production code |
 | `docs/` | Additional documentation |
+| `examples/` | Reference sketches and snippets, starting with Arduino examples. |
 | `README.md` | Season overview and quick start guide (this file). |
 When you create a new area, add a `README.md` inside that directory describing its contents and how to build or run the code.
 ## Development Workflow

--- a/IEEE2026/examples/arduinoBlinkExample/arduinoBlinkExample.ino
+++ b/IEEE2026/examples/arduinoBlinkExample/arduinoBlinkExample.ino
@@ -1,0 +1,20 @@
+// Pin number for the LED is 13
+const int ledPin = 13;
+
+// Delay time in milliseconds
+const int delayTime = 1000; // 1000 ms = 1 second
+
+void setup() {
+  // Set LED pin as output
+  pinMode(ledPin, OUTPUT);
+}
+
+void loop() {
+  // Turn LED on
+  digitalWrite(ledPin, HIGH);
+  delay(delayTime);
+
+  // Turn LED off
+  digitalWrite(ledPin, LOW);
+  delay(delayTime);
+}


### PR DESCRIPTION
## Summary
- document the new `examples/` directory in the IEEE2026 README
- add an `arduinoBlinkExample` sketch demonstrating a basic LED blink pattern

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d156f087b8832896baa8de6b17c216